### PR TITLE
Return 16 wifi-SSID's to stress test the config program 

### DIFF
--- a/lib/config/fnConfig.cpp
+++ b/lib/config/fnConfig.cpp
@@ -958,6 +958,14 @@ void fnConfig::_read_section_wifi(std::stringstream &ss)
             {
                 _wifi.passphrase = value;
             }
+            else if (strcasecmp(name.c_str(), "enabled") == 0)
+            {
+                if (strcasecmp(value.c_str(), "1") == 0)
+                    _wifi.enabled = true;
+                else
+                    _wifi.enabled = false; 
+            }
+
         }
     }
 }

--- a/lib/hardware/fnDummyWiFi.cpp
+++ b/lib/hardware/fnDummyWiFi.cpp
@@ -66,17 +66,19 @@ bool DummyWiFiManager::connected()
 */
 uint8_t DummyWiFiManager::scan_networks(uint8_t maxresults)
 {
-    return 1;
+    return 16;
 }
 
 int DummyWiFiManager::get_scan_result(uint8_t index, char ssid[32], uint8_t *rssi, uint8_t *channel, char bssid[18], uint8_t *encryption)
 {
+    /*
     if (index > 1)
         return -1;
+    */
 
     if (ssid != nullptr) {
         memset(ssid, 0, 32);
-        strlcpy(ssid, "Dummy Cafe", 32);
+        sprintf(ssid, "Dummy Cafe %d", index);
     }
 
     if (bssid != nullptr)


### PR DESCRIPTION
If you want to incorporate it, no biggie if not.

I found it useful for testing client programs that are going to get the list of SSID's since they need to be able to handle up to 16, so figure why not return 16 since it's not really used for anything else anyway.