### PR TITLE
implement missing host/mode values in set_device_filename

### DIFF
--- a/lib/device/rs232/fuji.cpp
+++ b/lib/device/rs232/fuji.cpp
@@ -1305,8 +1305,9 @@ void rs232Fuji::rs232_set_device_filename()
     // Handle DISK slots
     if (slot < MAX_DISK_DEVICES)
     {
-        // TODO: Set HOST and MODE
         memcpy(_fnDisks[cmdFrame.aux1].filename, tmp, MAX_FILENAME_LEN);
+        _fnDisks[cmdFrame.aux1].host_slot = host;
+        _fnDisks[cmdFrame.aux1].access_mode = mode;
         _populate_config_from_slots();
     }
     // Handle TAPE slots

--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -1405,8 +1405,9 @@ void sioFuji::sio_set_device_filename()
     // Handle DISK slots
     if (slot < MAX_DISK_DEVICES)
     {
-        // TODO: Set HOST and MODE
         memcpy(_fnDisks[cmdFrame.aux1].filename, tmp, MAX_FILENAME_LEN);
+        _fnDisks[cmdFrame.aux1].host_slot = host;
+        _fnDisks[cmdFrame.aux1].access_mode = mode;
         _populate_config_from_slots();
     }
     // Handle TAPE slots


### PR DESCRIPTION
I've pushed this change to fujinet-platformio too, it means my new config doesn't need to call sio_write_device_slots when saving changes for mounting an individual new entry, but original Config is unaffected because it does call sio_write_device_slots anyway.