### PR TITLE
fix for std::copy_n() function

### DIFF
--- a/lib/slip/ReadBlockRequest.cpp
+++ b/lib/slip/ReadBlockRequest.cpp
@@ -3,6 +3,7 @@
 #include "ReadBlockResponse.h"
 #include "SmartPortCodes.h"
 
+#include <algorithm>
 
 ReadBlockRequest::ReadBlockRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)
 	: Request(request_sequence_number, SP_READ_BLOCK, sp_unit), block_number_{} {}

--- a/lib/slip/ReadRequest.cpp
+++ b/lib/slip/ReadRequest.cpp
@@ -3,6 +3,7 @@
 #include "ReadResponse.h"
 #include "SmartPortCodes.h"
 
+#include <algorithm>
 
 ReadRequest::ReadRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)
 	: Request(request_sequence_number, SP_READ, sp_unit), byte_count_(), address_()

--- a/lib/slip/ReadResponse.cpp
+++ b/lib/slip/ReadResponse.cpp
@@ -1,6 +1,8 @@
 // ReSharper disable CppPassValueParameterByConstReference
 #include "ReadResponse.h"
 
+#include <algorithm>
+
 ReadResponse::ReadResponse(const uint8_t request_sequence_number, const uint8_t status) : Response(request_sequence_number, status) {}
 
 std::vector<uint8_t> ReadResponse::serialize() const

--- a/lib/slip/WriteBlockRequest.cpp
+++ b/lib/slip/WriteBlockRequest.cpp
@@ -3,6 +3,7 @@
 #include "WriteBlockResponse.h"
 #include "SmartPortCodes.h"
 
+#include <algorithm>
 
 WriteBlockRequest::WriteBlockRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)
 	: Request(request_sequence_number, SP_WRITE_BLOCK, sp_unit), block_number_{}, block_data_{} {}

--- a/lib/slip/WriteRequest.cpp
+++ b/lib/slip/WriteRequest.cpp
@@ -5,6 +5,7 @@
 #include "WriteResponse.h"
 #include "SmartPortCodes.h"
 
+#include <algorithm>
 
 WriteRequest::WriteRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)
 	: Request(request_sequence_number, SP_WRITE, sp_unit), byte_count_(), address_()


### PR DESCRIPTION
This adds the following to files to fix the errors around the `std::copy_n()` function.

```c
#include <algorithm>
```

Fixes error during compile:

```shell
/fujinet-pc/lib/slip/WriteRequest.cpp:48:14: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
   48 |         std::copy_n(ptr + offset, byte_count_.size(), byte_count_.begin());
      |              ^~~~~~
      |              copy
```

