### PR TITLE
On file open, resolve canonical path

### DIFF
--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -129,7 +129,7 @@ void NetworkProtocolFS::update_dir_filename(EdUrlParser *url)
 {
     size_t found = url->path.find_last_of("/");
 
-    dir = url->path.substr(0, found + 1);
+    dir = util_get_canonical_path(url->path.substr(0, found + 1));
     filename = url->path.substr(found + 1);
 
     // transform the possible everything wildcards

--- a/lib/slip/ReadBlockRequest.cpp
+++ b/lib/slip/ReadBlockRequest.cpp
@@ -2,6 +2,7 @@
 
 #include "ReadBlockResponse.h"
 #include "SmartPortCodes.h"
+#include <algorithm>
 
 
 ReadBlockRequest::ReadBlockRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)

--- a/lib/slip/ReadRequest.cpp
+++ b/lib/slip/ReadRequest.cpp
@@ -2,6 +2,7 @@
 
 #include "ReadResponse.h"
 #include "SmartPortCodes.h"
+#include <algorithm>
 
 
 ReadRequest::ReadRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)

--- a/lib/slip/ReadResponse.cpp
+++ b/lib/slip/ReadResponse.cpp
@@ -14,7 +14,7 @@ std::vector<uint8_t> ReadResponse::serialize() const
 
 void ReadResponse::set_data(const std::vector<uint8_t>::const_iterator& begin, const std::vector<uint8_t>::const_iterator& end)
 {
-	const size_t new_size = std::distance(begin, end);
+	const std::size_t new_size = std::distance(begin, end);
 	data_.resize(new_size);
 	std::copy(begin, end, data_.begin()); // NOLINT(performance-unnecessary-value-param)
 }

--- a/lib/slip/WriteBlockRequest.cpp
+++ b/lib/slip/WriteBlockRequest.cpp
@@ -2,7 +2,7 @@
 
 #include "WriteBlockResponse.h"
 #include "SmartPortCodes.h"
-
+#include <algorithm>
 
 WriteBlockRequest::WriteBlockRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)
 	: Request(request_sequence_number, SP_WRITE_BLOCK, sp_unit), block_number_{}, block_data_{} {}

--- a/lib/slip/WriteRequest.cpp
+++ b/lib/slip/WriteRequest.cpp
@@ -4,6 +4,7 @@
 
 #include "WriteResponse.h"
 #include "SmartPortCodes.h"
+#include <algorithm>
 
 
 WriteRequest::WriteRequest(const uint8_t request_sequence_number, const uint8_t sp_unit)

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -834,7 +834,7 @@ std::string util_get_canonical_path(std::string prefix)
     }
 
     // kludge
-    if (res[res.length() - 1] != '/')
+    if ((res[res.length() - 1] != '/') && (res.length() > 0))
         res.append("/");
 
     return res;


### PR DESCRIPTION
Fixes added to fujinet-platformio are replicated for fujinet-pc.

1. Corrected two issues found when using NOS:
 Unable to open files (such as binary load) from relative path that includes traversing through a parent directory. The logs would show a file open request such as:
 
    Before: `TNFS://my_path/my_sub1/../my_sub2/file.ext`
    After: `TNFS://my_path/my_sub2/file.ext`

2. `NCD Nn:` is supposed to clear the mount point. However, sending a null path through the util function to return a canonical path was incorrectly resolving to "/". A null path now resolves to null.

